### PR TITLE
added ability to handle several events in one method

### DIFF
--- a/eventbinder/src/main/java/com/google/web/bindery/event/gwt/rebind/binder/EventBinderGenerator.java
+++ b/eventbinder/src/main/java/com/google/web/bindery/event/gwt/rebind/binder/EventBinderGenerator.java
@@ -56,7 +56,7 @@ public class EventBinderGenerator extends Generator {
         new EventBinderWriter(
             logger,
             context.getTypeOracle().getType(GenericEvent.class.getCanonicalName()))
-                .writeDoBindEventHandlers(targetType, writer);
+                .writeDoBindEventHandlers(targetType, writer, context.getTypeOracle());
         writer.commit(logger);
       }
       return getFullyQualifiedGeneratedClassName(eventBinderType);

--- a/eventbinder/src/main/java/com/google/web/bindery/event/shared/binder/EventBinder.java
+++ b/eventbinder/src/main/java/com/google/web/bindery/event/shared/binder/EventBinder.java
@@ -43,6 +43,7 @@ import com.google.web.bindery.event.shared.HandlerRegistration;
  *   // Interesting stuff goes here...
  * }
  * </pre>
+ * See {@link EventHandler} for more usage examples.
  *
  * @param <T> type of object being bound, which should be the same as the type
  *        enclosing this interface

--- a/eventbinder/src/main/java/com/google/web/bindery/event/shared/binder/EventHandler.java
+++ b/eventbinder/src/main/java/com/google/web/bindery/event/shared/binder/EventHandler.java
@@ -49,4 +49,42 @@ import java.lang.annotation.Target;
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
-public @interface EventHandler {}
+public @interface EventHandler {
+
+  /**
+   * <p>Events that should be handled by the annotated method.</p>
+   *
+   * <p>If handles array is empty (default) then the method handles only event
+   * of type of the method's parameter and in this case the method's parameter
+   * is required. If handles array is not empty the method's parameter may be
+   * omitted.</p>
+   *
+   * <p>Every event type from this array should be assignable to the parameter
+   * of the method.</p>
+   *
+   * <p>Examples:</p>
+   * <ul>
+   *     <li>Method onEvent1 handles only EventOne</li>
+   *     <li>Method onEvent2 handles EventOne and EventTwo without event parameter</li>
+   *     <li>Method onEvent3 handles EventOne and EventTwo and has event parameter</li>
+   * </ul>
+   *
+   * <pre>
+   * {@literal @}EventHandler
+   * void onEvent1(EventOne event) {
+   *   doSomething1();
+   * }
+   * {@literal @}EventHandler(handles = {EventOne.class, EventTwo.class})
+   * void onEvent2() {
+   *   doSomething2();
+   * }
+   *
+   * {@literal @}EventHandler(handles = {EventOne.class, EventTwo.class})
+   * void onEvent3(ParentOfEventOneAndTwo event) {
+   *   doSomething3();
+   * }
+   * </pre>
+   *
+   */
+  Class<? extends GenericEvent>[] handles() default {};
+}

--- a/eventbinder/src/test/java/com/google/web/bindery/event/gwt/rebind/binder/EventBinderWriterTest.java
+++ b/eventbinder/src/test/java/com/google/web/bindery/event/gwt/rebind/binder/EventBinderWriterTest.java
@@ -17,6 +17,7 @@ package com.google.web.bindery.event.gwt.rebind.binder;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.contains;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.isNull;
@@ -31,15 +32,21 @@ import com.google.gwt.core.ext.UnableToCompleteException;
 import com.google.gwt.core.ext.typeinfo.JClassType;
 import com.google.gwt.core.ext.typeinfo.JMethod;
 import com.google.gwt.core.ext.typeinfo.JType;
+import com.google.gwt.core.ext.typeinfo.TypeOracle;
 import com.google.gwt.user.rebind.SourceWriter;
 import com.google.gwt.user.rebind.StringSourceWriter;
 import com.google.web.bindery.event.shared.binder.EventHandler;
-
+import com.google.web.bindery.event.shared.binder.GenericEvent;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.invocation.InvocationOnMock;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.stubbing.Answer;
+
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Tests for {@link EventBinderWriter}. Most functionality should be covered by
@@ -53,49 +60,69 @@ public class EventBinderWriterTest {
 
   @Mock private JClassType target;
   @Mock private TreeLogger logger;
-  @Mock private JClassType genericEventType;
+
+  private JClassType genericEventType;
+  private Map<Class<? extends GenericEvent>, JClassType> eventTypes;
+  private TypeOracle typeOracle;
   private EventBinderWriter writer;
   private SourceWriter output;
 
   @Before
   public void setUp() {
+    eventTypes = new HashMap<Class<? extends GenericEvent>, JClassType>();
+
+    typeOracle = createTypeOracle();
+    genericEventType = getEventType(GenericEvent.class);
     writer = new EventBinderWriter(logger, genericEventType);
     output = new StringSourceWriter();
   }
 
   @Test
   public void shouldWriteDoBindEventHandler() throws Exception {
-    JClassType eventType1 = newEventType("MyEvent1");
-    JClassType eventType2 = newEventType("MyEvent2");
+    JClassType eventType1 = getEventType(MyEvent1.class);
+    JClassType eventType2 = getEventType(MyEvent2.class);
     JMethod method1 = newMethod("method1", eventType1);
     JMethod method2 = newMethod("method2", eventType2);
+    JMethod method3 = newMethod("method3", new JType[] {genericEventType},
+        new Class[] {MyEvent1.class, MyEvent2.class});
+    JMethod method4 = newMethod("method4", new JType[] {},
+        new Class[] {MyEvent1.class});
 
     when(target.getQualifiedSourceName()).thenReturn("MyTarget");
-    when(target.getInheritableMethods()).thenReturn(new JMethod[] {method1, method2});
+    when(target.getInheritableMethods()).thenReturn(new JMethod[] {method1, method2, method3, method4});
 
-    writer.writeDoBindEventHandlers(target, output);
+    writer.writeDoBindEventHandlers(target, output, typeOracle);
 
     assertEquals(join(
         "protected List<HandlerRegistration> doBindEventHandlers("
             + "final MyTarget target, EventBus eventBus) {",
         "  List<HandlerRegistration> registrations = new LinkedList<HandlerRegistration>();",
-        "  bind(eventBus, registrations, MyEvent1.class, new GenericEventHandler() {",
-        "    public void handleEvent(GenericEvent event) { target.method1((MyEvent1) event); }",
+        "  bind(eventBus, registrations, " + className(MyEvent1.class) + ".class, new GenericEventHandler() {",
+        "    public void handleEvent(GenericEvent event) { target.method1((" + className(MyEvent1.class) + ") event); }",
         "  });",
-        "  bind(eventBus, registrations, MyEvent2.class, new GenericEventHandler() {",
-        "    public void handleEvent(GenericEvent event) { target.method2((MyEvent2) event); }",
+        "  bind(eventBus, registrations, " + className(MyEvent2.class) +".class, new GenericEventHandler() {",
+        "    public void handleEvent(GenericEvent event) { target.method2((" + className(MyEvent2.class) + ") event); }",
+        "  });",
+        "  bind(eventBus, registrations, " + className(MyEvent1.class) + ".class, new GenericEventHandler() {",
+        "    public void handleEvent(GenericEvent event) { target.method3((" + className(MyEvent1.class) +") event); }",
+        "  });",
+        "  bind(eventBus, registrations, " + className(MyEvent2.class) + ".class, new GenericEventHandler() {",
+        "    public void handleEvent(GenericEvent event) { target.method3((" + className(MyEvent2.class) + ") event); }",
+        "  });",
+        "  bind(eventBus, registrations, " + className(MyEvent1.class) + ".class, new GenericEventHandler() {",
+        "    public void handleEvent(GenericEvent event) { target.method4(); }",
         "  });",
         "  return registrations;",
         "}"), output.toString());
   }
 
   @Test
-  public void shouldFailOnZeroParameters() throws Exception {
+  public void shouldFailOnZeroParametersWithoutEvents() throws Exception {
     JMethod method = newMethod("myMethod");
     when(target.getInheritableMethods()).thenReturn(new JMethod[] {method});
 
     try {
-      writer.writeDoBindEventHandlers(target, output);
+      writer.writeDoBindEventHandlers(target, output, typeOracle);
       fail("Exception not thrown");
     } catch (UnableToCompleteException expected) {}
 
@@ -109,7 +136,7 @@ public class EventBinderWriterTest {
     when(target.getInheritableMethods()).thenReturn(new JMethod[] {method});
 
     try {
-      writer.writeDoBindEventHandlers(target, output);
+      writer.writeDoBindEventHandlers(target, output, typeOracle);
       fail("Exception not thrown");
     } catch (UnableToCompleteException expected) {}
 
@@ -127,7 +154,23 @@ public class EventBinderWriterTest {
     when(target.getInheritableMethods()).thenReturn(new JMethod[] {method});
 
     try {
-      writer.writeDoBindEventHandlers(target, output);
+      writer.writeDoBindEventHandlers(target, output, typeOracle);
+      fail("Exception not thrown");
+    } catch (UnableToCompleteException expected) {}
+
+    verify(logger).log(
+        eq(Type.ERROR), contains("myMethod"), isNull(Throwable.class), isNull(HelpInfo.class));
+  }
+
+  @Test
+  public void shouldFailForEventWhichIsNotAssignableToParameter() throws Exception {
+    JClassType eventType1 = getEventType(MyEvent1.class);
+
+    JMethod method = newMethod("myMethod", new JType[] {eventType1}, new Class[] {MyEvent2.class});
+    when(target.getInheritableMethods()).thenReturn(new JMethod[] {method});
+
+    try {
+      writer.writeDoBindEventHandlers(target, output, typeOracle);
       fail("Exception not thrown");
     } catch (UnableToCompleteException expected) {}
 
@@ -144,7 +187,7 @@ public class EventBinderWriterTest {
     when(target.getInheritableMethods()).thenReturn(new JMethod[] {method});
 
     try {
-      writer.writeDoBindEventHandlers(target, output);
+      writer.writeDoBindEventHandlers(target, output, typeOracle);
       fail("Exception not thrown");
     } catch (UnableToCompleteException expected) {}
 
@@ -154,14 +197,14 @@ public class EventBinderWriterTest {
   
   @Test
   public void shouldFailOnAbstractParameter() throws Exception {
-    JClassType paramType = newEventType("AbstractEvent");
+    JClassType paramType = getEventType(AbstractEvent.class);
     when(paramType.isAbstract()).thenReturn(true);
     
     JMethod method = newMethod("myMethod", paramType);
     when(target.getInheritableMethods()).thenReturn(new JMethod[] {method});
     
     try {
-      writer.writeDoBindEventHandlers(target, output);
+      writer.writeDoBindEventHandlers(target, output, typeOracle);
       fail("Exception not thrown");
     } catch (UnableToCompleteException expected) {}
     
@@ -169,20 +212,55 @@ public class EventBinderWriterTest {
         eq(Type.ERROR), contains("myMethod"), isNull(Throwable.class), isNull(HelpInfo.class));
   }
 
+  @SuppressWarnings("unchecked")
   private JMethod newMethod(String name, JType... params) {
+    return newMethod(name, params, new Class[0]);
+  }
+
+  @SuppressWarnings("unchecked")
+  private JMethod newMethod(String name, JType[] params, Class[] events) {
+    EventHandler eventHandler = mock(EventHandler.class);
+    when(eventHandler.handles()).thenReturn(events);
+
     JMethod method = mock(JMethod.class);
-    when(method.getAnnotation(EventHandler.class)).thenReturn(mock(EventHandler.class));
+    when(method.getAnnotation(EventHandler.class)).thenReturn(eventHandler);
     when(method.getName()).thenReturn(name);
     when(method.getParameterTypes()).thenReturn(params);
     return method;
   }
 
-  private JClassType newEventType(String name) {
+  private JClassType getEventType(Class<? extends GenericEvent> event) {
+    if (eventTypes.containsKey(event)) {
+      return eventTypes.get(event);
+    }
     JClassType type = mock(JClassType.class);
+    eventTypes.put(event, type);
+
     when(type.isClassOrInterface()).thenReturn(type);
-    when(type.isAssignableTo(genericEventType)).thenReturn(true);
-    when(type.getQualifiedSourceName()).thenReturn(name);
+    when(type.isAssignableTo(getEventType(GenericEvent.class))).thenReturn(true);
+    when(type.getOracle()).thenReturn(typeOracle);
+    when(type.getQualifiedSourceName()).thenReturn(className(event));
     return type;
+  }
+
+  private TypeOracle createTypeOracle() {
+    TypeOracle typeOracle = mock(TypeOracle.class);
+    when(typeOracle.findType(anyString())).then(new Answer<JClassType>() {
+      @Override
+      public JClassType answer(InvocationOnMock invocationOnMock) throws Throwable {
+        String parameter = (String) invocationOnMock.getArguments()[0];
+        Class<? extends GenericEvent> klass;
+        try {
+          klass = (Class<? extends GenericEvent>) Class.forName(parameter);
+        } catch (ClassNotFoundException ex) {
+          char[] klassName = parameter.toCharArray();
+          klassName[parameter.lastIndexOf('.')] = '$';
+          klass = (Class<? extends GenericEvent>) Class.forName(String.valueOf(klassName));
+        }
+        return getEventType(klass);
+      }
+    });
+    return typeOracle;
   }
 
   private String join(String... strings) {
@@ -192,4 +270,14 @@ public class EventBinderWriterTest {
     }
     return builder.toString();
   }
+
+  private String className(Class<? extends GenericEvent> event) {
+    return event.getName().replace('$', '.');
+  }
+
+  public static class MyEvent1 extends GenericEvent {}
+
+  public static class MyEvent2 extends GenericEvent {}
+
+  public static abstract class AbstractEvent extends GenericEvent {}
 }

--- a/eventbinder/src/test/java/com/google/web/bindery/event/shared/binder/EventBinderTest.java
+++ b/eventbinder/src/test/java/com/google/web/bindery/event/shared/binder/EventBinderTest.java
@@ -43,12 +43,15 @@ public class EventBinderTest extends GWTTestCase {
     assertEquals(0, presenter.firstEventsHandled);
     eventBus.fireEvent(new FirstEvent());
     assertEquals(1, presenter.firstEventsHandled);
+    assertEquals(1, presenter.firstEventsWithoutParameterHandled);
+    assertEquals(1, presenter.firstAndSecondEventsHandled);
 
     // Test another event twice
     assertEquals(0, presenter.secondEventsHandled);
     eventBus.fireEvent(new SecondEvent());
     eventBus.fireEvent(new SecondEvent());
     assertEquals(2, presenter.secondEventsHandled);
+    assertEquals(3, presenter.firstAndSecondEventsHandled);
   }
 
   public void testEventBinder_unbindEventHandlers() {
@@ -57,27 +60,34 @@ public class EventBinderTest extends GWTTestCase {
     TestPresenter.MyEventBinder binder = GWT.create(TestPresenter.MyEventBinder.class);
     HandlerRegistration registration = binder.bindEventHandlers(presenter, eventBus);
     assertEquals(0, presenter.firstEventsHandled);
+    assertEquals(0, presenter.firstEventsWithoutParameterHandled);
     assertEquals(0, presenter.secondEventsHandled);
 
     // Before unregistering
     eventBus.fireEvent(new FirstEvent());
     eventBus.fireEvent(new SecondEvent());
     assertEquals(1, presenter.firstEventsHandled);
+    assertEquals(1, presenter.firstEventsWithoutParameterHandled);
     assertEquals(1, presenter.secondEventsHandled);
+    assertEquals(2, presenter.firstAndSecondEventsHandled);
 
     // After unregistering
     registration.removeHandler();
     eventBus.fireEvent(new FirstEvent());
     eventBus.fireEvent(new SecondEvent());
     assertEquals(1, presenter.firstEventsHandled);
+    assertEquals(1, presenter.firstEventsWithoutParameterHandled);
     assertEquals(1, presenter.secondEventsHandled);
+    assertEquals(2, presenter.firstAndSecondEventsHandled);
 
     // After re-registering
     binder.bindEventHandlers(presenter, eventBus);
     eventBus.fireEvent(new FirstEvent());
     eventBus.fireEvent(new SecondEvent());
     assertEquals(2, presenter.firstEventsHandled);
+    assertEquals(2, presenter.firstEventsWithoutParameterHandled);
     assertEquals(2, presenter.secondEventsHandled);
+    assertEquals(4, presenter.firstAndSecondEventsHandled);
   }
 
   public void testEventBinder_withLegacyEventBus() {
@@ -104,6 +114,7 @@ public class EventBinderTest extends GWTTestCase {
 
     // FirstEvent has a handler in both classes, so it should be handled twice
     assertEquals(1, presenter.firstEventsHandled);
+    assertEquals(1, presenter.firstEventsWithoutParameterHandled);
     assertEquals(1, presenter.subclassFirstEventsHandled);
 
     // SecondEvent's handler is overridden in the subclass, so it should only be handled there
@@ -112,6 +123,9 @@ public class EventBinderTest extends GWTTestCase {
 
     // ThirdEvent is only handled in the superclass
     assertEquals(1, presenter.thirdEventsHandled);
+
+    // First+Second events are handled in superclass
+    assertEquals(2, presenter.firstAndSecondEventsHandled);
   }
 
 
@@ -121,6 +135,8 @@ public class EventBinderTest extends GWTTestCase {
     int firstEventsHandled;
     int secondEventsHandled;
     int thirdEventsHandled;
+    int firstAndSecondEventsHandled;
+    int firstEventsWithoutParameterHandled;
 
     @EventHandler
     void onFirstEvent(FirstEvent e) {
@@ -135,6 +151,16 @@ public class EventBinderTest extends GWTTestCase {
     @EventHandler
     void onThirdEvent(ThirdEvent e) {
       thirdEventsHandled++;
+    }
+
+    @EventHandler(handles = {FirstEvent.class, SecondEvent.class})
+    void onFirstAndSecondEvent(GenericEvent event) {
+      firstAndSecondEventsHandled++;
+    }
+
+    @EventHandler(handles = {FirstEvent.class})
+    void onFirstEventWithoutParameter() {
+        firstEventsWithoutParameterHandled++;
     }
   }
 


### PR DESCRIPTION
Sometimes it's useful to have ability to handle several events in one method when you have to react identically to several events. For example you have to reload some grid when user is created or removed. Currently you have to write two methods with the same body:

```
@EventHandler
void onUserCreated(UserCreationEvent e) {
   grid.refresh();
}

@EventHandler
void onUserRemoved(UserRemovedEvent e) {
   grid.refresh();
}
```

My suggestion is to use the following syntax for this case:

```
@EventHandler(events = {UserCreationEvent.class, UserRemovedEvent.class})
void refreshGrid(GenericEvent event) {
   grid.refresh();
}
```
