### PR TITLE
Test multiple gwt versions

### DIFF
--- a/eventbinder-sample/pom.xml
+++ b/eventbinder-sample/pom.xml
@@ -38,6 +38,11 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>com.google.gwt</groupId>
+      <artifactId>gwt-dev</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>com.google.gwt.eventbinder</groupId>
       <artifactId>eventbinder</artifactId>
       <scope>provided</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
         <plugin>
           <groupId>net.ltgt.gwt.maven</groupId>
           <artifactId>gwt-maven-plugin</artifactId>
-          <version>1.0-alpha-3</version>
+          <version>1.0-beta-1</version>
           <extensions>true</extensions>
         </plugin>
       </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+    <gwt.version>2.6.0</gwt.version>
   </properties>
 
   <licenses>
@@ -51,12 +53,12 @@
       <dependency>
         <groupId>com.google.gwt</groupId>
         <artifactId>gwt-dev</artifactId>
-        <version>2.6.0</version>
+        <version>${gwt.version}</version>
       </dependency>
       <dependency>
         <groupId>com.google.gwt</groupId>
         <artifactId>gwt-user</artifactId>
-        <version>2.6.0</version>
+        <version>${gwt.version}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Fixes #26 (I manually tested with GWT 2.7.0, but it can be done easily in a CI server; see https://github.com/tbroyer/gwt-maven-plugin/blob/master/.travis.yml for an example)